### PR TITLE
v0.2.0 `no_std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ls7366"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["joshua salzedo <thHunkn0WNd@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ This driver should work for any concrete `embedded_hal::blocking::spi` implement
 Testing was done against a [Dual LS7366R buffer chip](https://www.superdroidrobots.com/shop/item.aspx/dual-ls7366r-quadrature-encoder-buffer/1523/)
 On a RPi Model 4B.
 
+### Bonus Feature!
+as of v0.2.0 the library is built with `no_std`.
+
 See documentation for full driver details.
 
 ## Building the [quickstart](./examples/quickstart.rs):

--- a/examples/quickstart.rs
+++ b/examples/quickstart.rs
@@ -1,4 +1,3 @@
-use std::error::Error;
 use std::thread::sleep;
 use std::time::Duration;
 
@@ -6,19 +5,19 @@ use rppal::spi::{Bus, Mode, SlaveSelect, Spi};
 
 use ls7366::Ls7366;
 
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() {
     // create an instance of an SPI object
     // In this case, the buffer is on SPI0 and SS1.
     // The chip acts in Mode0.
-    let spi_1 = Spi::new(Bus::Spi0, SlaveSelect::Ss1, 14_000_000, Mode::Mode0)?;
+    let spi_1 = Spi::new(Bus::Spi0, SlaveSelect::Ss1, 14_000_000, Mode::Mode0).unwrap();
 
     // Construct a driver instance from the SPI interface, using default chip configurations.
-    let mut spi_driver = Ls7366::new(spi_1)?;
+    let mut spi_driver = Ls7366::new(spi_1).unwrap();
 
     // Loop and read the counter.
     loop {
-        let result = spi_driver.get_count()?;
-        let status = spi_driver.get_status()?;
+        let result = spi_driver.get_count().unwrap();
+        let status = spi_driver.get_status().unwrap();
         println!("read data:= {:?}\n status := {:?}", result, status);
         sleep(Duration::from_secs(1));
     }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,15 +1,12 @@
-use std::error::Error;
 use bitfield::fmt::Formatter;
 
 #[derive(Clone, Debug)]
 pub enum EncoderError {
-    FailedDecode(String),
+    FailedDecode,
 }
-impl Error for EncoderError {
 
-}
-impl std::fmt::Display for EncoderError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for EncoderError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         write!(f, "{:?}", self)
     }
 }

--- a/src/ir.rs
+++ b/src/ir.rs
@@ -94,7 +94,7 @@ impl Decodable for Target {
             0b101 => Ok(Target::Otr),
             0b110 => Ok(Target::Str),
             0b111 => Ok(Target::None),
-            _ => { Err(EncoderError::FailedDecode("failed to decode Target".to_string())) }
+            _ => { Err(EncoderError::FailedDecode) }
         }
     }
 }
@@ -117,7 +117,7 @@ impl Decodable for Action {
             0b01 => Ok(Action::Read),
             0b10 => Ok(Action::Write),
             0b11 => Ok(Action::Load),
-            _ => Err(EncoderError::FailedDecode("failed to decode Action".to_string()))
+            _ => Err(EncoderError::FailedDecode)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,7 +192,7 @@ impl<SPI, SpiError> Ls7366<SPI>
             return Err(Error::PayloadTooBig);
         }
         let payload: &[u8] = &[ir_cmd.encode()];
-        let mut payload = [payload, data].concat();
+        let payload = [payload, data].concat();
         self.interface.write(&payload)?;
         Ok(())
     }
@@ -215,7 +215,7 @@ impl<SPI, SpiError> Ls7366<SPI>
             target,
             action: Action::Read,
         };
-        let mut tx_buffer = &mut [ir.encode(), 0x00, 0x00, 0x00, 0x00];
+        let tx_buffer = &mut [ir.encode(), 0x00, 0x00, 0x00, 0x00];
 
         let result = self.interface.transfer(tx_buffer)?;
         rx_buffer.copy_from_slice(&result[1..]);
@@ -263,7 +263,7 @@ impl<SPI, SpiError> Ls7366<SPI>
     /// Other sources of error responses may arise from the underlying HAL implementation and are
     /// bubbled up.
     pub fn act<'a>(&mut self, command: InstructionRegister, data: &'a mut [u8]) -> Result<& 'a [u8], Error<SpiError>> {
-        let mut tx_buffer: &[u8] = &[command.encode()];
+        let tx_buffer: &[u8] = &[command.encode()];
         match command.action {
             Action::Clear | Action::Load => {
                 if data.len() > 0 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,8 @@
 //!         # flag_on_cy: false,
 //!     };
 //!
-//!     driver.write_register(Target::Mdr0, &vec![mdr0_configuration.encode()]).unwrap();
-//!     driver.write_register(Target::Mdr1, &vec![mdr1_configuration.encode()]).unwrap();
+//!     driver.write_register(Target::Mdr0, &[mdr0_configuration.encode()]).unwrap();
+//!     driver.write_register(Target::Mdr1, &[mdr1_configuration.encode()]).unwrap();
 //!
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,19 @@
 //!
 //! 1. Build an instance of [`Mdr0`] and [`Mdr1`] with the desired configuration.
 //! 2. Write these instances into the relevant registers.
-//! ```no_run
+//! ```
 //! use ls7366::mdr0::{QuadCountMode, CycleCountMode, FilterClockDivisionFactor,IndexMode, Mdr0};
 //! use ls7366::mdr1::{CounterMode, Mdr1};
 //! use ls7366::{Ls7366, Target, Encodable};
-//! # use rppal::spi::Spi; // concrete SPI implementation
-//! # use std::error::Error;
+//! use embedded_hal_mock::spi::Mock;
+//! use embedded_hal_mock::spi::Transaction as SpiTransaction;
+//! # let expectations = [
+//! #     SpiTransaction::write(vec![0b10001000, 0b10100110]),
+//! #     SpiTransaction::write(vec![0b10010000, 0b00000101])
+//! # ];
+//! # let spi = Mock::new(&expectations);
+//! # let mut driver = Ls7366::new_uninit(spi);
 //! // --- snip ---
-//! # fn your_code(spi_driver: &mut Ls7366<Spi>) {
 //!     let mdr0_configuration = Mdr0{
 //!         quad_count_mode: QuadCountMode::Quad2x,
 //!         filter_clock : FilterClockDivisionFactor::Two,
@@ -68,10 +73,9 @@
 //!         # flag_on_cy: false,
 //!     };
 //!
-//!     spi_driver.write_register(Target::Mdr0, &vec![mdr0_configuration.encode()]).unwrap();
-//!     spi_driver.write_register(Target::Mdr1, &vec![mdr1_configuration.encode()]).unwrap();
-//!     // --- Snip ---
-//! }
+//!     driver.write_register(Target::Mdr0, &vec![mdr0_configuration.encode()]).unwrap();
+//!     driver.write_register(Target::Mdr1, &vec![mdr1_configuration.encode()]).unwrap();
+//!
 //! ```
 //!
 //! [`SPI traits`]: https://docs.rs/embedded-hal/0.2.3/embedded_hal/blocking/spi/index.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,7 +266,7 @@ impl<SPI, SpiError> Ls7366<SPI>
         let tx_buffer: &[u8] = &[command.encode()];
         match command.action {
             Action::Clear | Action::Load => {
-                if data.len() > 0 {
+                if data.len() > 1 {
                     Err(Error::PayloadTooBig)
                 } else {
                     self.interface.write(&tx_buffer)?;
@@ -280,7 +280,7 @@ impl<SPI, SpiError> Ls7366<SPI>
                 Ok(data)
             }
             Action::Write => {
-                if data.len() > 4 {
+                if data.len() > 5 {
                     Err(Error::PayloadTooBig)
                 } else {
                     self.interface.write(&tx_buffer)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 //! This driver should work with any SPI interface as long as it implements
 //! the blocking `embedded_hal` [`SPI traits`].
 //!
+//! The library is built with `no_std`.
+//!
 //!
 //! # Examples
 //! Bare-minimum boilerplate to read from the buffer:

--- a/src/mdr0.rs
+++ b/src/mdr0.rs
@@ -115,7 +115,7 @@ impl Decodable for QuadCountMode {
             0b01 => Ok(QuadCountMode::Quad1x),
             0b10 => Ok(QuadCountMode::Quad2x),
             0b11 => Ok(QuadCountMode::Quad4x),
-            _ => Err(EncoderError::FailedDecode("failed to parse QuadCountMode".to_string())),
+            _ => Err(EncoderError::FailedDecode),
         }
     }
 }
@@ -138,7 +138,7 @@ impl Decodable for IndexMode {
             0b01 => Ok(IndexMode::LoadCntr),
             0b10 => Ok(IndexMode::ClearCntr),
             0b11 => Ok(IndexMode::LoadOtr),
-            _ => Err(EncoderError::FailedDecode("failed to parse IndexMode".to_string())),
+            _ => Err(EncoderError::FailedDecode),
         }
     }
 }
@@ -161,7 +161,7 @@ impl Decodable for CycleCountMode {
             0b01 => Ok(CycleCountMode::SingleCycle),
             0b10 => Ok(CycleCountMode::RangeLimit),
             0b11 => Ok(CycleCountMode::ModuloN),
-            _ => Err(EncoderError::FailedDecode("failed to parse CycleCount".to_string())),
+            _ => Err(EncoderError::FailedDecode),
         }
     }
 }

--- a/src/mdr1.rs
+++ b/src/mdr1.rs
@@ -69,7 +69,7 @@ impl Decodable for CounterMode {
             0b01 => Ok(CounterMode::Byte3),
             0b10 => Ok(CounterMode::Byte2),
             0b11 => Ok(CounterMode::Byte1),
-            _ => Err(EncoderError::FailedDecode("failed to decode CounterMode".to_string()))
+            _ => Err(EncoderError::FailedDecode)
         }
     }
 }

--- a/src/str_register.rs
+++ b/src/str_register.rs
@@ -81,10 +81,10 @@ impl Decodable for Str {
         Ok(Self {
             sign_bit: SignBit::decode(payload.sign())?,
             count_direction: Direction::decode(payload.count_direction())?,
-            compare: payload.power_loss(),
+            compare: payload.compare(),
             cary: payload.cary(),
             borrow: payload.borrow_(),
-            power_loss: payload.compare(),
+            power_loss: payload.power_loss(),
             index: payload.index(),
             count_enabled: payload.count_enabled(),
         })

--- a/tests/test_io.rs
+++ b/tests/test_io.rs
@@ -10,7 +10,7 @@ mod tests {
     use ls7366::str_register;
 
     #[test]
-    fn test_get_count() -> Result<(), Box<dyn Error>> {
+    fn test_get_count() {
         let expectations = [
             SpiTransaction::transfer(vec![InstructionRegister {
                 target: Target::Cntr,
@@ -37,15 +37,14 @@ mod tests {
         let spi = Mock::new(&expectations);
         let mut driver = Ls7366::new_uninit(spi);
 
-        let result = driver.get_count()?;
+        let result = driver.get_count().unwrap();
 
         assert_eq!(result, 0xDEADBEEF);
-        assert_eq!(driver.get_count()?, -0xDEADBEEF);
-        Ok(())
+        assert_eq!(driver.get_count().unwrap(), -0xDEADBEEF);
     }
 
     #[test]
-    fn test_status() -> Result<(), Box<dyn Error>> {
+    fn test_status() {
         let expectations = [
             // STR read, will return positive sign
             SpiTransaction::transfer(vec![InstructionRegister {
@@ -86,15 +85,13 @@ mod tests {
         let mut driver = Ls7366::new_uninit(spi);
 
         for payload in expected_results.iter() {
-            let result = driver.get_status()?;
+            let result = driver.get_status().unwrap();
             assert_eq!(&result, payload);
         }
-
-        Ok(())
     }
 
     #[test]
-    fn test_write_register() -> Result<(), Box<dyn Error>> {
+    fn test_write_register() {
         let expectations = [
             // Dtr write
             SpiTransaction::write(vec![InstructionRegister {
@@ -114,8 +111,7 @@ mod tests {
         let spi = Mock::new(&expectations);
         let mut driver = Ls7366::new_uninit(spi);
 
-        driver.write_register(Target::Dtr, &vec![0xBA, 0xAD, 0xBE, 0xEF])?;
-        driver.write_register(Target::Mdr0, &vec![0xFD, 0xFD, 0xFD, 0xFD])?;
-        Ok(())
+        driver.write_register(Target::Dtr, &vec![0xBA, 0xAD, 0xBE, 0xEF]).unwrap();
+        driver.write_register(Target::Mdr0, &vec![0xFD, 0xFD, 0xFD, 0xFD]).unwrap();
     }
 }

--- a/tests/test_io.rs
+++ b/tests/test_io.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use std::error::Error;
+    
 
     use embedded_hal_mock::spi::{Mock, Transaction as SpiTransaction};
 

--- a/tests/test_io.rs
+++ b/tests/test_io.rs
@@ -1,7 +1,5 @@
 #[cfg(test)]
 mod tests {
-    
-
     use embedded_hal_mock::spi::{Mock, Transaction as SpiTransaction};
 
     use ls7366::{Action, Encodable, Target};
@@ -44,7 +42,7 @@ mod tests {
     }
 
     #[test]
-    fn test_status() {
+    fn test_status_a() {
         let expectations = [
             // STR read, will return positive sign
             SpiTransaction::transfer(vec![InstructionRegister {
@@ -88,6 +86,30 @@ mod tests {
             let result = driver.get_status().unwrap();
             assert_eq!(&result, payload);
         }
+    }
+
+    #[test]
+    fn test_status_b() {
+        let expectations = [
+            // STR read, will return positive sign
+            SpiTransaction::transfer(vec![InstructionRegister {
+                target: Target::Str,
+                action: Action::Read,
+            }.encode(), 0x00, 0x00, 0x00, 0x00], vec![0x00, 0x00, 0x00, 0x00, 0b00000100],
+            )];
+        let spi = Mock::new(&expectations);
+        let mut driver = Ls7366::new_uninit(spi);
+        let result = driver.get_status().unwrap();
+        assert_eq!(result, str_register::Str {
+            cary: false,
+            borrow: false,
+            compare: false,
+            index: false,
+            count_enabled: false,
+            power_loss: true,
+            count_direction: str_register::Direction::Down,
+            sign_bit: str_register::SignBit::Positive,
+        });
     }
 
     #[test]


### PR DESCRIPTION
- fixes the `Str` carry bit being misinterpreted as the power loss bit and vice versa.
- now does NOT require the standard library!