### PR TITLE
Release v0.2.1

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,5 +1,8 @@
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 
-#[build]
-#target = "armv7-unknown-linux-gnueabihf"
+[target.thumbv7em-none-eabihf]
+rustflags = [
+  "-C", "link-arg=-Tlink.x",
+]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2018"
 license = "Apache-2.0"
 description = "Rust interface to the LS7366 quadrature encoder buffer."
 repository = "https://github.com/theunkn0wn1/LS7366_rust"
+categories = ["embedded", "no-std"]
+keywords = ["ls7366", "quadrature_encoder"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ls7366"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["joshua salzedo <thHunkn0WNd@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,9 +197,17 @@ impl<SPI, SpiError> Ls7366<SPI>
         if data.len() > 4 {
             return Err(Error::PayloadTooBig);
         }
-        let payload: &[u8] = &[ir_cmd.encode()];
-        let payload = [payload, data].concat();
-        self.interface.write(&payload)?;
+
+        let encoded = ir_cmd.encode();
+        let payload: &mut [u8] = &mut [encoded, encoded, encoded, encoded, encoded];
+
+        let mut i = 1;
+        for datum in data {
+            payload[i] = *datum;
+            i+=1;
+        }
+        // only write as many bits as we had data, +1 for the IR.
+        self.interface.write(&payload[0.. data.len()+1])?;
         Ok(())
     }
     /// Executes a read operation against specified register, returning up to 4 bytes from the chip.


### PR DESCRIPTION
## Bug fixes
#2 fixed usage of `concat`, which doesn't appear to be in every target's `core` crate.
 - solved by implementing `concat` the long way